### PR TITLE
Removed occurrence of neg_slope from train_mlp_pytorch.py

### DIFF
--- a/assignment_1/1_mlp_cnn/code/train_mlp_pytorch.py
+++ b/assignment_1/1_mlp_cnn/code/train_mlp_pytorch.py
@@ -78,9 +78,7 @@ def train():
         dnn_hidden_units = [int(dnn_hidden_unit_) for dnn_hidden_unit_ in dnn_hidden_units]
     else:
         dnn_hidden_units = []
-    
-    neg_slope = FLAGS.neg_slope
-    
+        
     ########################
     # PUT YOUR CODE HERE  #
     #######################


### PR DESCRIPTION
Neg_slope was still used in the pytorch implementation, although all other references tot his parameter were removed in a a previous commit